### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,17 +9,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3
         with:
           java-version: '21'
           distribution: 'temurin'
           cache: maven
 
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
## Summary
- The `build.yaml` workflow's third-party Actions were referenced by floating tag — pins each `uses:` to its current tag's commit SHA, keeping the tag as a trailing comment.
- Dependabot's `github-actions` ecosystem was already enabled here, so it will keep these SHAs current automatically going forward.

Part of an org-wide public-repo hygiene pass.