### PR TITLE
Fix author filter in dependabot auto-merge sweep

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -140,7 +140,7 @@ jobs:
           pr_numbers="$(
             gh pr list --repo "$REPOSITORY" --base updates --state open \
               --json number,author,isDraft,reviewDecision \
-              --jq '[.[] | select(.author.login == "dependabot[bot]" and .isDraft == false and .reviewDecision == "APPROVED")] | .[].number'
+              --jq '[.[] | select(.author.is_bot == true and (.author.login | test("dependabot"; "i")) and .isDraft == false and .reviewDecision == "APPROVED")] | .[].number'
           )"
 
           if [ -z "$pr_numbers" ]; then


### PR DESCRIPTION
Follow-up to #1738. Manually triggered the new sweep job right after that merged and it found "No approved Dependabot PRs ready to merge" despite 17 open, approved PRs targeting `updates`.

Root cause: \`gh pr list --json author\` returns the bot's login as \`app/dependabot\` (GraphQL actor format), not the REST-style \`dependabot[bot]\` used by \`github.event.pull_request.user.login\` elsewhere in this workflow. The sweep's jq filter compared against the wrong string and matched nothing.

Fix: match on \`author.is_bot == true\` plus a case-insensitive substring check on the login instead of an exact string match.