### PR TITLE
Fix gh api invocation: --jq doesn't take jq's --arg flag

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -164,8 +164,8 @@ jobs:
                 # build result rather than trusting the earlier approval alone.
                 head_sha="$(gh pr view "$pr_number" --repo "$REPOSITORY" --json headRefOid -q .headRefOid)"
                 build_conclusion="$(
-                  gh api "repos/$REPOSITORY/actions/workflows/build.yaml/runs?event=pull_request&per_page=100" \
-                    --jq --arg sha "$head_sha" '
+                  gh api "repos/$REPOSITORY/actions/workflows/build.yaml/runs?event=pull_request&per_page=100" |
+                    jq -r --arg sha "$head_sha" '
                       [.workflow_runs[] | select(.head_sha == $sha)]
                       | sort_by(.created_at)
                       | reverse


### PR DESCRIPTION
Follow-up to #1740. The build-recheck added there failed on the very first live run against PR #1729 with \`accepts 1 arg(s), received 4\`.

\`gh api --jq\` takes a single jq program string; it has no \`--arg\` flag of its own the way the standalone \`jq\` CLI does. \`gh api URL --jq --arg sha "$head_sha" '...'\` made \`gh\` swallow \`--arg\` as the jq program itself, leaving \`sha\`, the SHA value, and the real jq expression as three stray positional args on top of the URL — hence "4".

Fix: pipe the API response into a separate \`jq -r --arg sha ... '...'\` call, same pattern the \`prepare\` job already uses successfully. Verified locally against a real PR before pushing.