### PR TITLE
Request a rebase for DIRTY PRs too, not just BEHIND

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -180,9 +180,12 @@ jobs:
                   echo "Merge failed for PR #$pr_number; will retry next sweep."
                 fi
                 ;;
-              BEHIND)
+              BEHIND|DIRTY)
+                # BEHIND: base moved past this PR. DIRTY: real conflict, often
+                # caused by an earlier PR in this same sweep landing first.
+                # Dependabot regenerates the diff against the new base either way.
                 gh pr comment "$pr_number" --repo "$REPOSITORY" --body "@dependabot rebase"
-                echo "PR #$pr_number is behind updates; requested a Dependabot rebase."
+                echo "PR #$pr_number is $merge_state against updates; requested a Dependabot rebase."
                 ;;
               UNKNOWN)
                 echo "PR #$pr_number mergeability still unresolved after retries; will retry next sweep."


### PR DESCRIPTION
Follow-up to #1741. That fix went live and the sweep correctly merged 15 of 17 approved PRs in one run. Of the two left: #1642 was correctly held back (build still pending on its current head), but #1673 ended up \`DIRTY\` (\`mergeable: CONFLICTING\`) — an earlier PR in the same sweep merged first and moved \`updates\` out from under it.

The case statement only requested a Dependabot rebase for \`BEHIND\`; \`DIRTY\` fell into the default branch and just got logged and skipped, with nothing to ever un-stick it. Since a sweep merging multiple PRs in one pass will keep producing DIRTY PRs among the later ones as a normal, expected outcome (not an edge case), this needs handling every run, not just occasionally.

Fix: treat \`DIRTY\` the same as \`BEHIND\` — comment \`@dependabot rebase\`, which regenerates the diff against the current base regardless of whether the PR was behind or conflicting. Verified locally with a dry run (stubbing only the mutating \`gh pr merge\`/\`gh pr comment\` calls) against the two real PRs currently in this state.