### PR TITLE
Fix Dependabot security alerts (log4j-core)

### DIFF
--- a/kafka-demos/flink/datastream/pom.xml
+++ b/kafka-demos/flink/datastream/pom.xml
@@ -35,7 +35,7 @@ under the License.
 		<target.java.version>17</target.java.version>
 		<maven.compiler.source>${target.java.version}</maven.compiler.source>
 		<maven.compiler.target>${target.java.version}</maven.compiler.target>
-		<log4j.version>2.25.2</log4j.version>
+		<log4j.version>2.25.4</log4j.version>
 		<protobuf-version>3.23.2</protobuf-version>
 	</properties>
 


### PR DESCRIPTION
Bumps `log4j.version` from 2.25.2 to 2.25.4 in `kafka-demos/flink/datastream/pom.xml`, resolving the 4 open Dependabot alerts for `log4j-core`.

Replaces #1754, which was mistakenly opened against `main` instead of `updates` (this repo merges Dependabot fixes into `updates` for manual verification, not `main`).

Verified: `mvn compile` succeeds in `kafka-demos/flink/datastream`.